### PR TITLE
Remoção de 'ft.' do título do vídeo

### DIFF
--- a/src/script/script.js
+++ b/src/script/script.js
@@ -7,7 +7,7 @@ var getSongTitle = function() {
     title = title.replace(/(\[.*?\]|\(.*?\)) */g, "").trim(); 
     title = title.replace("-", "OR");
     title = title.replace(":", '');
-    title = title.replace(/DVD|HD|CD|full performance|full album|album|lyric video|with lyrics|w\/lyrics|lyrics|lyric|official video|"|'/ig, '');
+    title = title.replace(/DVD|FT|HD|CD|full performance|full album|album|lyric video|with lyrics|w\/lyrics|lyrics|lyric|official video|"|'/ig, '');
     title = title.split('OR');
     if(title[0] == "") {
             title = title[1] + " OR " + title[2];


### PR DESCRIPTION
Remoção de 'Ft', pois o Spotify não trabalha com Ft assim a consulta não é encontrada. Sem o 'Ft' o Spotify encontra o resultado.

Exemplos: 
https://www.youtube.com/watch?v=M6mPU3zFM_k&list=PL_Q15fKxrBb5r3VmBvh7TVNMLx_F1sxfa&index=8
https://www.youtube.com/watch?v=_b-FdGeNcYo&index=3&list=PL_Q15fKxrBb5r3VmBvh7TVNMLx_F1sxfa

Outra proposta é remover as #. Poderia criar um regex que varre a partir # até o primeiro espaço.
